### PR TITLE
Fixes #6024: Rudder API documentation doesn't include API version 5

### DIFF
--- a/src/api_v2/parameter.md
+++ b/src/api_v2/parameter.md
@@ -33,7 +33,7 @@ https://github.com/Normation/rudder/blob/master/rudder-web/src/main/scala/com/no
     /**
     @api {get} /api/parameters 1. List all Parameters
     @apiVersion 2.0.0
-    @apiName listGroups
+    @apiName listParameters
     @apiGroup Parameters
     
     @apiExample Example usage:


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6024